### PR TITLE
fix for No module named pyspark

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,7 +48,8 @@ default.hadoop_spark.yarn.warehouse_hdfs                  = "/user/#{node.hadoop
 # Use comma to separate multiple archives, and use # to create the symlink on YARN runtime working directory.
 default.hadoop_spark.yarn.dist.archives                   = ""
 default.hadoop_spark.yarn.dist.files                      = ""
-#default.hadoop_spark.yarn.dist.jars                       = ""
+#default.hadoop_spark.yarn.dist.jars                      = ""
+default.hadoop_spark.pyFiles                              = "local://#{node.hadoop_spark.base_dir}/python/lib/pyspark.zip"
 default.hadoop_spark.yarn.jars                            = "local://#{node.hadoop_spark.base_dir}/jars/*"
 default.hadoop_spark.yarn.am.memory                       = "512m"
 default.hadoop_spark.yarn.containerLauncherMaxThreads     = 25

--- a/templates/default/spark-defaults.conf.erb
+++ b/templates/default/spark-defaults.conf.erb
@@ -46,6 +46,8 @@ spark.yarn.containerLauncherMaxThreads     <%= node.hadoop_spark.yarn.containerL
 # Use comma to separate multiple archives, and use # to create the symlink on YARN runtime working directory.
 #spark.yarn.dist.archives                   hdfs://<%= @namenode_ip %>:<%= node.apache_hadoop.nn.port %><%= node.hadoop_spark.yarn.archive_hdfs %>
 spark.yarn.archive                         hdfs://<%= @namenode_ip %>:<%= node.apache_hadoop.nn.port %><%= node.hadoop_spark.yarn.archive_hdfs %>
+# Files to place on the PYTHONPATH for Python apps. Launching Python applications through spark-submit is currently only supported for local files.
+spark.submit.pyFiles                       <%= node.hadoop_spark.pyFiles %>
 spark.sql.warehouse.dir                    hdfs://<%= @namenode_ip %>:<%= node.apache_hadoop.nn.port %><%= node.hadoop_spark.yarn.warehouse_hdfs %>
 # <%= node.hadoop_spark.yarn.dist.archives %> 
 #spark.yarn.jars                            <%= node.hadoop_spark.yarn.jars %>


### PR DESCRIPTION
Tested with 
~~~~{.python}
%pyspark
words = sc.textFile("file:///srv/hops/domain1/logs/server.log") \
 .flatMap(lambda x: x.lower().split(" ")) \
 .filter(lambda x: x.isalpha()).map(lambda x: (x, 1)) \
 .reduceByKey(lambda a,b: a+b)
 
sqlContext.registerDataFrameAsTable(sqlContext.createDataFrame(words, ['word', 'count']), 'words')
~~~~

`%sql 
select word, max(count) from words group by word`